### PR TITLE
Add Thai Word Spell Corrector by employing Thai2Vec

### DIFF
--- a/notebooks/thai_word_spell_checker_with_thai2vec.ipynb
+++ b/notebooks/thai_word_spell_checker_with_thai2vec.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Thai word Spell Checker using Thai2Vec\n",
+    "\n",
+    "\n",
+    "Regarding to improve Peter Norvig's spell checker, we can use thai2vec improve word spelling corrector by approximating word probabiliies.\n",
+    "\n",
+    "Credit to [Kaggle Spell Checker using Word2vec by CPMP](https://www.kaggle.com/cpmpml/spell-checker-using-word2vec) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np # linear algebra\n",
+    "import pandas as pd # data processing, CSV file I/O (e.g. pd.read_csv)\n",
+    "import gensim\n",
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thai2vec_path = './thai2vec.vec' # or use your own path\n",
+    "model = gensim.models.KeyedVectors.load_word2vec_format(thai2vec_path)\n",
+    "words = model.index2word\n",
+    "\n",
+    "w_rank = {}\n",
+    "for i,word in enumerate(words):\n",
+    "    w_rank[word] = i\n",
+    "\n",
+    "WORDS = w_rank"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thai_letters = 'กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤฤๅลฦฦๅวศษสหฬอฮะัาำิีึืุูเแโใไ็่้๊๋์'\n",
+    "\n",
+    "def words(text): return re.findall(r'\\w+', text.lower())\n",
+    "\n",
+    "def P(word): \n",
+    "    \"Probability of `word`.\"\n",
+    "    # use inverse of rank as proxy\n",
+    "    # returns 0 if the word isn't in the dictionary\n",
+    "    return - WORDS.get(word, 0)\n",
+    "\n",
+    "def correction(word): \n",
+    "    \"Most probable spelling correction for word.\"\n",
+    "    return max(candidates(word), key=P)\n",
+    "\n",
+    "def candidates(word): \n",
+    "    \"Generate possible spelling corrections for word.\"\n",
+    "    return (known([word]) or known(edits1(word)) or known(edits2(word)) or [word])\n",
+    "\n",
+    "def known(words): \n",
+    "    \"The subset of `words` that appear in the dictionary of WORDS.\"\n",
+    "    return set(w for w in words if w in WORDS)\n",
+    "\n",
+    "def edits1(word):\n",
+    "    \"All edits that are one edit away from `word`.\"\n",
+    "    letters    = thai_letters\n",
+    "    splits     = [(word[:i], word[i:])    for i in range(len(word) + 1)]\n",
+    "    deletes    = [L + R[1:]               for L, R in splits if R]\n",
+    "    transposes = [L + R[1] + R[0] + R[2:] for L, R in splits if len(R)>1]\n",
+    "    replaces   = [L + c + R[1:]           for L, R in splits if R for c in letters]\n",
+    "    inserts    = [L + c + R               for L, R in splits for c in letters]\n",
+    "    return set(deletes + transposes + replaces + inserts)\n",
+    "\n",
+    "def edits2(word): \n",
+    "    \"All edits that are two edits away from `word`.\"\n",
+    "    return (e2 for e1 in edits1(word) for e2 in edits1(e1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'พัฒนา'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "correction('พัดนา')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'จ้า'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "correction('จย้า')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'พยายาม'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "correction('พยายา')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I have created Thai word spell corrector by using thai2vec for employing the computed rank in thai2vec for selecting the most probable word.

For example:

```
correction('พัดนา') -> 'พัฒนา'
correction('สมาชิ') -> 'สมาชิก'
correction('จย้า') -> 'จ้า'
```

reference: [Spell Checker using Word2vec
](https://www.kaggle.com/cpmpml/spell-checker-using-word2vec)